### PR TITLE
Fix heading capitalization in backend README

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # README
 
-## getting start
+## Getting Started
 
 ### 必要なもの
 


### PR DESCRIPTION
## Summary
- correct the casing of the Getting Started heading in `backend/README.md`

## Testing
- `docker compose run --rm api bundle exec rails test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fcac78cb883249516fa3644530a5d