### PR TITLE
feat: cloud schedulerにする

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -252,6 +252,108 @@ run-all-jobs: check-project ## 全ジョブを順次実行
 	gcloud run jobs execute daily-summary-job --region=$(REGION) --wait
 	@echo "✅ 全ジョブの実行が完了しました"
 
+# Cloud Scheduler操作
+scheduler-list: check-project ## Cloud Schedulerジョブ一覧を表示
+	@echo "📋 Cloud Schedulerジョブ一覧:"
+	@echo "プロジェクト: $(PROJECT_ID)"
+	gcloud scheduler jobs list --location=$(REGION) --format="table(name,schedule,timeZone,state,lastAttemptTime)"
+
+scheduler-status: check-project ## Cloud Schedulerジョブの詳細状態を表示
+	@echo "📊 Cloud Schedulerジョブの詳細:"
+	@echo "プロジェクト: $(PROJECT_ID)"
+	@echo ""
+	@echo "=== 記事要約スケジューラー ==="
+	@gcloud scheduler jobs describe article-summary-scheduler --location=$(REGION) --format="table(name,schedule,timeZone,state,lastAttemptTime,httpTarget.uri)" 2>/dev/null || echo "❌ article-summary-scheduler が見つかりません"
+	@echo ""
+	@echo "=== 日次要約スケジューラー ==="
+	@gcloud scheduler jobs describe daily-summary-scheduler --location=$(REGION) --format="table(name,schedule,timeZone,state,lastAttemptTime,httpTarget.uri)" 2>/dev/null || echo "❌ daily-summary-scheduler が見つかりません"
+
+scheduler-run-article: check-project ## 記事要約スケジューラーを手動実行
+	@echo "▶️  記事要約スケジューラーを手動実行中..."
+	@echo "プロジェクト: $(PROJECT_ID)"
+	gcloud scheduler jobs run article-summary-scheduler --location=$(REGION)
+	@echo "✅ 手動実行をトリガーしました（実行完了まで数分かかる場合があります）"
+
+scheduler-run-daily: check-project ## 日次要約スケジューラーを手動実行
+	@echo "▶️  日次要約スケジューラーを手動実行中..."
+	@echo "プロジェクト: $(PROJECT_ID)"
+	gcloud scheduler jobs run daily-summary-scheduler --location=$(REGION)
+	@echo "✅ 手動実行をトリガーしました（実行完了まで数分かかる場合があります）"
+
+scheduler-pause-article: check-project ## 記事要約スケジューラーを一時停止
+	@echo "⏸️  記事要約スケジューラーを一時停止中..."
+	@echo "プロジェクト: $(PROJECT_ID)"
+	gcloud scheduler jobs pause article-summary-scheduler --location=$(REGION)
+	@echo "✅ スケジューラーを一時停止しました"
+
+scheduler-pause-daily: check-project ## 日次要約スケジューラーを一時停止
+	@echo "⏸️  日次要約スケジューラーを一時停止中..."
+	@echo "プロジェクト: $(PROJECT_ID)"
+	gcloud scheduler jobs pause daily-summary-scheduler --location=$(REGION)
+	@echo "✅ スケジューラーを一時停止しました"
+
+scheduler-resume-article: check-project ## 記事要約スケジューラーを再開
+	@echo "▶️  記事要約スケジューラーを再開中..."
+	@echo "プロジェクト: $(PROJECT_ID)"
+	gcloud scheduler jobs resume article-summary-scheduler --location=$(REGION)
+	@echo "✅ スケジューラーを再開しました"
+
+scheduler-resume-daily: check-project ## 日次要約スケジューラーを再開
+	@echo "▶️  日次要約スケジューラーを再開中..."
+	@echo "プロジェクト: $(PROJECT_ID)"
+	gcloud scheduler jobs resume daily-summary-scheduler --location=$(REGION)
+	@echo "✅ スケジューラーを再開しました"
+
+scheduler-pause-all: scheduler-pause-article scheduler-pause-daily ## 全スケジューラーを一時停止
+
+scheduler-resume-all: scheduler-resume-article scheduler-resume-daily ## 全スケジューラーを再開
+
+scheduler-logs: check-project ## Cloud Schedulerのログを表示
+	@echo "📜 Cloud Schedulerのログ:"
+	@echo "プロジェクト: $(PROJECT_ID)"
+	@echo ""
+	@echo "どのスケジューラーのログを表示しますか？"
+	@echo "1) article-summary-scheduler"
+	@echo "2) daily-summary-scheduler"
+	@echo "3) 全て"
+	@read -p "選択してください (1-3): " choice; \
+	case $$choice in \
+		1) gcloud logging read "resource.type=cloud_scheduler_job AND resource.labels.job_id=article-summary-scheduler" --limit=50 --format="table(timestamp,severity,jsonPayload.message)" ;; \
+		2) gcloud logging read "resource.type=cloud_scheduler_job AND resource.labels.job_id=daily-summary-scheduler" --limit=50 --format="table(timestamp,severity,jsonPayload.message)" ;; \
+		3) gcloud logging read "resource.type=cloud_scheduler_job" --limit=50 --format="table(timestamp,severity,resource.labels.job_id,jsonPayload.message)" ;; \
+		*) echo "❌ 無効な選択です" ;; \
+	esac
+
+plan-scheduler: check-project ## Cloud Schedulerのみプラン表示
+	terraform plan \
+		-target=google_service_account.cloud_scheduler \
+		-target=google_project_iam_member.cloud_scheduler_run_invoker \
+		-target=google_cloud_scheduler_job.article_summary \
+		-target=google_cloud_scheduler_job.daily_summary
+
+apply-scheduler: check-project ## Cloud Schedulerのみ更新
+	terraform apply -auto-approve \
+		-target=google_service_account.cloud_scheduler \
+		-target=google_project_iam_member.cloud_scheduler_run_invoker \
+		-target=google_cloud_scheduler_job.article_summary \
+		-target=google_cloud_scheduler_job.daily_summary
+
+import-scheduler: check-project ## 既存のCloud Schedulerジョブをインポート
+	@echo "Cloud Schedulerジョブをインポート中..."
+	@echo "プロジェクト: $(PROJECT_ID)"
+	@if gcloud scheduler jobs describe article-summary-scheduler --location=$(REGION) >/dev/null 2>&1; then \
+		terraform import google_cloud_scheduler_job.article_summary projects/$(PROJECT_ID)/locations/$(REGION)/jobs/article-summary-scheduler; \
+		echo "✅ article-summary-scheduler をインポートしました"; \
+	else \
+		echo "❌ article-summary-scheduler が見つかりません"; \
+	fi
+	@if gcloud scheduler jobs describe daily-summary-scheduler --location=$(REGION) >/dev/null 2>&1; then \
+		terraform import google_cloud_scheduler_job.daily_summary projects/$(PROJECT_ID)/locations/$(REGION)/jobs/daily-summary-scheduler; \
+		echo "✅ daily-summary-scheduler をインポートしました"; \
+	else \
+		echo "❌ daily-summary-scheduler が見つかりません"; \
+	fi
+
 # インポート操作
 import-cloud-run: check-project ## 既存のCloud Runサービスをインポート
 	@echo "Cloud Runサービスをインポート中..."
@@ -338,7 +440,7 @@ import-service-accounts: check-project ## 既存のサービスアカウント�
 import-apis: check-project ## 既存のAPIサービスをインポート
 	@echo "APIサービスをインポート中..."
 	@echo "プロジェクト: $(PROJECT_ID)"
-	@for api in run.googleapis.com sqladmin.googleapis.com secretmanager.googleapis.com cloudbuild.googleapis.com containerregistry.googleapis.com artifactregistry.googleapis.com logging.googleapis.com monitoring.googleapis.com compute.googleapis.com servicenetworking.googleapis.com vpcaccess.googleapis.com storage.googleapis.com; do \
+	@for api in run.googleapis.com sqladmin.googleapis.com secretmanager.googleapis.com cloudbuild.googleapis.com containerregistry.googleapis.com artifactregistry.googleapis.com logging.googleapis.com monitoring.googleapis.com compute.googleapis.com servicenetworking.googleapis.com vpcaccess.googleapis.com storage.googleapis.com cloudscheduler.googleapis.com; do \
 		echo "インポート中: $$api"; \
 		terraform import "google_project_service.required_apis[\"$$api\"]" $(PROJECT_ID)/$$api || echo "$$api のインポートに失敗（既に有効化済みの可能性）"; \
 	done
@@ -514,7 +616,7 @@ setup: init setup-prod validate ## 初期セットアップを実行
 	@echo "3. make apply でリソースを作成"
 
 # 全体インポート
-import-all: import-apis import-service-accounts import-cloud-sql import-cloud-sql-database import-cloud-run import-cloud-run-job import-secret import-artifact-registry import-storage import-storage-iam ## 全てのリソースをインポート
+import-all: import-apis import-service-accounts import-cloud-sql import-cloud-sql-database import-cloud-run import-cloud-run-job import-scheduler import-secret import-artifact-registry import-storage import-storage-iam ## 全てのリソースをインポート
 
 # 状態管理
 init-local: check-project ## ローカル状態でTerraformを初期化

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,5 +1,5 @@
 # Makefile for Terraform Operations
-# Summeryme AI Backend Infrastructure
+# Summaryme AI Backend Infrastructure
 
 .PHONY: help init plan apply destroy validate format check check-all clean import output state lint lint-fix checkov checkov-json checkov-quiet security-all
 
@@ -24,7 +24,7 @@ check-project:
 
 # デフォルトターゲット
 help: ## このヘルプメッセージを表示
-	@echo "Summeryme AI Backend - Terraform Operations"
+	@echo "Summaryme AI Backend - Terraform Operations"
 	@echo ""
 	@echo "現在のプロジェクト: $(PROJECT_ID)"
 	@echo ""

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -430,6 +430,12 @@ make security-scan
 
 ## 🔄 バージョン履歴
 
+### v2.1.0 (2025-06-22)
+- ✨ Cloud Schedulerサポート追加
+- ✨ バッチジョブのスケジュール実行対応
+- ✨ Cloud Storageバケット追加
+- ✨ Gemini APIキー管理追加
+
 ### v2.0.0 (2025-05-31)
 - ✨ ベストプラクティスに沿ったファイル構成に変更
 - ✨ 機能別ファイル分離（providers.tf, locals.tf, apis.tf等）

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
-# Summeryme AI Backend - Terraform Configuration
+# Summaryme AI Backend - Terraform Configuration
 
-このディレクトリには、Summeryme AI BackendのGCPリソースをTerraformで管理するための設定ファイルが含まれています。
+このディレクトリには、Summaryme AI BackendのGCPリソースをTerraformで管理するための設定ファイルが含まれています。
 
 ## 🗄️ 状態管理（GCS Backend）
 

--- a/terraform/SCHEDULER_SETUP.md
+++ b/terraform/SCHEDULER_SETUP.md
@@ -1,0 +1,161 @@
+# Cloud Scheduler セットアップガイド
+
+このドキュメントでは、バッチジョブのスケジュール実行の設定と動作確認方法について説明します。
+
+## 実装内容
+
+### 1. Cloud Scheduler ジョブ
+
+`cloud_scheduler.tf` で以下の2つのスケジュールジョブを定義しています：
+
+#### 記事要約ジョブ (`article-summary-scheduler`)
+
+- **タイムゾーン**: Asia/Tokyo
+- **対象ジョブ**: `article-summary-job`
+
+#### 日次要約ジョブ (`daily-summary-scheduler`)
+
+- **タイムゾーン**: Asia/Tokyo
+- **対象ジョブ**: `daily-summary-job`
+
+### 2. セキュリティ設定
+
+- 専用のサービスアカウント `${service_name}-scheduler-sa` を作成
+- Cloud Run Jobs を実行するための `roles/run.invoker` 権限を付与
+
+## デプロイ手順
+
+1. Terraform の初期化（まだの場合）:
+
+   ```bash
+   cd terraform
+   make init
+   ```
+
+2. 変更内容の確認:
+
+   ```bash
+   make plan
+   ```
+
+3. デプロイの実行:
+
+   ```bash
+   make apply
+   ```
+
+## 動作確認方法
+
+### 1. Cloud Scheduler ジョブの確認
+
+Google Cloud Console から確認:
+
+```bash
+gcloud scheduler jobs list --location=asia-northeast1
+```
+
+または、Web コンソールから:
+
+https://console.cloud.google.com/cloudscheduler
+
+### 2. 手動実行でのテスト
+
+#### 記事要約ジョブの手動実行:
+
+```bash
+gcloud scheduler jobs run article-summary-scheduler --location=asia-northeast1
+```
+
+#### 日次要約ジョブの手動実行:
+
+```bash
+gcloud scheduler jobs run daily-summary-scheduler --location=asia-northeast1
+```
+
+### 3. Cloud Run Job の実行状態確認
+
+```bash
+# ジョブの一覧表示
+gcloud run jobs list --region=asia-northeast1
+
+# 特定ジョブの実行履歴確認
+gcloud run jobs executions list --job=article-summary-job --region=asia-northeast1
+gcloud run jobs executions list --job=daily-summary-job --region=asia-northeast1
+
+# 実行ログの確認
+gcloud logging read "resource.type=cloud_run_job AND resource.labels.job_name=article-summary-job" --limit=50
+gcloud logging read "resource.type=cloud_run_job AND resource.labels.job_name=daily-summary-job" --limit=50
+```
+
+### 4. スケジューラーの一時停止/再開
+
+一時停止:
+
+```bash
+gcloud scheduler jobs pause article-summary-scheduler --location=asia-northeast1
+gcloud scheduler jobs pause daily-summary-scheduler --location=asia-northeast1
+```
+
+再開:
+
+```bash
+gcloud scheduler jobs resume article-summary-scheduler --location=asia-northeast1
+gcloud scheduler jobs resume daily-summary-scheduler --location=asia-northeast1
+```
+
+## スケジュール設定の変更
+
+スケジュールを変更する場合は、`cloud_scheduler.tf` の `schedule` パラメータを編集してください。
+
+### cron 形式の例
+
+- `0 */3 * * *` - 3時間ごと
+- `0 6 * * *` - 毎日午前6時
+- `0 */6 * * *` - 6時間ごと
+- `0 0,12 * * *` - 毎日午前0時と午後12時
+- `0 9-18 * * 1-5` - 平日の9時から18時まで毎時
+
+変更後は以下を実行:
+
+```bash
+cd terraform
+make plan
+make apply
+```
+
+## トラブルシューティング
+
+### ジョブが実行されない場合
+
+1. サービスアカウントの権限を確認:
+   ```bash
+   gcloud projects get-iam-policy ${PROJECT_ID} --flatten="bindings[].members" --filter="serviceAccount:*scheduler-sa*"
+   ```
+
+2. Cloud Scheduler API が有効か確認:
+   ```bash
+   gcloud services list --enabled | grep cloudscheduler
+   ```
+
+3. Cloud Run Job のステータスを確認:
+   ```bash
+   gcloud run jobs describe article-summary-job --region=asia-northeast1
+   gcloud run jobs describe daily-summary-job --region=asia-northeast1
+   ```
+
+### ログの詳細確認
+
+Cloud Logging でより詳細なログを確認:
+```bash
+# Scheduler のログ
+gcloud logging read "resource.type=cloud_scheduler_job" --limit=50
+
+# Job 実行のエラーログ
+gcloud logging read "severity>=ERROR AND resource.type=cloud_run_job" --limit=50
+```
+
+## 注意事項
+
+- スケジュール実行は Asia/Tokyo タイムゾーンで設定されています
+- Cloud Run Jobs の同時実行数は1に設定されているため、前の実行が完了してから次が開始されます
+- 実行に失敗した場合、Cloud Scheduler は自動的にリトライを行います（デフォルト設定）

--- a/terraform/TERRAFORM_DOCS.md
+++ b/terraform/TERRAFORM_DOCS.md
@@ -26,8 +26,12 @@ No modules.
 | [google_artifact_registry_repository_iam_member.cloud_run_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
 | [google_artifact_registry_repository_iam_member.github_actions_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
 | [google_cloud_run_service_iam_member.public_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service_iam_member) | resource |
+| [google_cloud_run_v2_job.article_summary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job) | resource |
+| [google_cloud_run_v2_job.daily_summary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job) | resource |
 | [google_cloud_run_v2_job.migrate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job) | resource |
 | [google_cloud_run_v2_service.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service) | resource |
+| [google_cloud_scheduler_job.article_summary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_scheduler_job) | resource |
+| [google_cloud_scheduler_job.daily_summary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_scheduler_job) | resource |
 | [google_compute_global_address.private_ip_address](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_network.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
 | [google_compute_router.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
@@ -35,20 +39,26 @@ No modules.
 | [google_compute_subnetwork.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
 | [google_project_iam_member.cloud_run_secret_accessor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cloud_run_sql_client](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.cloud_scheduler_run_invoker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.github_actions_editor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.github_actions_run_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.github_actions_secret_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.github_actions_sql_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.required_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_secret_manager_secret.db_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret.gemini_api_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret_iam_member.db_password_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.gemini_api_key_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.db_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_service_account.cloud_run](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.cloud_scheduler](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.github_actions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_networking_connection.private_vpc_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
 | [google_sql_database.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
 | [google_sql_database_instance.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
 | [google_sql_user.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
+| [google_storage_bucket.audio_files](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_member.audio_bucket_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_vpc_access_connector.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vpc_access_connector) | resource |
 | [random_password.db_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
@@ -73,8 +83,13 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_article_summary_job_location"></a> [article\_summary\_job\_location](#output\_article\_summary\_job\_location) | Location of the Cloud Run article summary job |
+| <a name="output_article_summary_job_name"></a> [article\_summary\_job\_name](#output\_article\_summary\_job\_name) | Name of the Cloud Run article summary job |
 | <a name="output_artifact_registry_repository_name"></a> [artifact\_registry\_repository\_name](#output\_artifact\_registry\_repository\_name) | Name of the Artifact Registry repository |
 | <a name="output_artifact_registry_repository_url"></a> [artifact\_registry\_repository\_url](#output\_artifact\_registry\_repository\_url) | URL of the Artifact Registry repository |
+| <a name="output_audio_storage_bucket_location"></a> [audio\_storage\_bucket\_location](#output\_audio\_storage\_bucket\_location) | Location of the GCS bucket for audio files |
+| <a name="output_audio_storage_bucket_name"></a> [audio\_storage\_bucket\_name](#output\_audio\_storage\_bucket\_name) | Name of the GCS bucket for audio files |
+| <a name="output_audio_storage_bucket_url"></a> [audio\_storage\_bucket\_url](#output\_audio\_storage\_bucket\_url) | URL of the GCS bucket for audio files |
 | <a name="output_backend_configuration"></a> [backend\_configuration](#output\_backend\_configuration) | GCS backend configuration for Terraform state management |
 | <a name="output_cloud_run_service_account_email"></a> [cloud\_run\_service\_account\_email](#output\_cloud\_run\_service\_account\_email) | Email address of the Cloud Run service account |
 | <a name="output_cloud_run_service_account_id"></a> [cloud\_run\_service\_account\_id](#output\_cloud\_run\_service\_account\_id) | Unique ID of the Cloud Run service account |
@@ -87,11 +102,15 @@ No modules.
 | <a name="output_cloud_sql_instance_name"></a> [cloud\_sql\_instance\_name](#output\_cloud\_sql\_instance\_name) | Name of the Cloud SQL instance |
 | <a name="output_cloud_sql_instance_public_ip_address"></a> [cloud\_sql\_instance\_public\_ip\_address](#output\_cloud\_sql\_instance\_public\_ip\_address) | Public IP address of the Cloud SQL instance (if enabled) |
 | <a name="output_container_image_url"></a> [container\_image\_url](#output\_container\_image\_url) | Full URL of the container image used for deployment |
+| <a name="output_daily_summary_job_location"></a> [daily\_summary\_job\_location](#output\_daily\_summary\_job\_location) | Location of the Cloud Run daily summary job |
+| <a name="output_daily_summary_job_name"></a> [daily\_summary\_job\_name](#output\_daily\_summary\_job\_name) | Name of the Cloud Run daily summary job |
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Name of the application database |
 | <a name="output_database_user"></a> [database\_user](#output\_database\_user) | Database user name for application connections |
 | <a name="output_db_password_secret_id"></a> [db\_password\_secret\_id](#output\_db\_password\_secret\_id) | Secret Manager secret ID for database password |
 | <a name="output_db_password_secret_name"></a> [db\_password\_secret\_name](#output\_db\_password\_secret\_name) | Full resource name of the database password secret |
 | <a name="output_environment"></a> [environment](#output\_environment) | Environment name (development, staging, production) |
+| <a name="output_gemini_api_key_secret_id"></a> [gemini\_api\_key\_secret\_id](#output\_gemini\_api\_key\_secret\_id) | Secret Manager secret ID for GEMINI API key |
+| <a name="output_gemini_api_key_secret_name"></a> [gemini\_api\_key\_secret\_name](#output\_gemini\_api\_key\_secret\_name) | Full resource name of the GEMINI API key secret |
 | <a name="output_github_actions_service_account_email"></a> [github\_actions\_service\_account\_email](#output\_github\_actions\_service\_account\_email) | Email address of the GitHub Actions service account |
 | <a name="output_github_actions_service_account_id"></a> [github\_actions\_service\_account\_id](#output\_github\_actions\_service\_account\_id) | Unique ID of the GitHub Actions service account |
 | <a name="output_migration_job_location"></a> [migration\_job\_location](#output\_migration\_job\_location) | Location of the Cloud Run migration job |

--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -1,5 +1,5 @@
 # Google Cloud APIs
-# Summeryme AI Backend
+# Summaryme AI Backend
 
 # 必要なAPIの有効化
 resource "google_project_service" "required_apis" {

--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -1,5 +1,5 @@
 # Artifact Registry
-# Summeryme AI Backend
+# Summaryme AI Backend
 
 # Artifact Registry リポジトリ
 resource "google_artifact_registry_repository" "backend" {

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -1,5 +1,5 @@
 # Cloud Run
-# Summeryme AI Backend
+# Summaryme AI Backend
 
 # VPCアクセスコネクタ
 resource "google_vpc_access_connector" "main" {

--- a/terraform/cloud_scheduler.tf
+++ b/terraform/cloud_scheduler.tf
@@ -1,0 +1,64 @@
+# Cloud Scheduler
+# バッチジョブのスケジュール実行
+
+# Cloud Scheduler のサービスアカウント
+resource "google_service_account" "cloud_scheduler" {
+  account_id   = "${local.service_name}-scheduler-sa"
+  display_name = "Cloud Scheduler Service Account for ${local.service_name}"
+  description  = "Service account for Cloud Scheduler to trigger Cloud Run Jobs"
+}
+
+# Cloud Scheduler に Cloud Run Jobs を実行する権限を付与
+resource "google_project_iam_member" "cloud_scheduler_run_invoker" {
+  project = var.project_id
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${google_service_account.cloud_scheduler.email}"
+}
+
+# 記事要約ジョブのスケジューラー
+resource "google_cloud_scheduler_job" "article_summary" {
+  name        = "article-summary-scheduler"
+  description = "Trigger article summary batch job"
+  schedule    = "0 5,11,17 * * *" # 3時間ごとに実行
+  time_zone   = "Asia/Tokyo"
+  region      = var.region
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.article_summary.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.cloud_scheduler.email
+    }
+  }
+
+  depends_on = [
+    google_project_service.required_apis,
+    google_cloud_run_v2_job.article_summary,
+    google_project_iam_member.cloud_scheduler_run_invoker
+  ]
+}
+
+# 日次要約ジョブのスケジューラー
+resource "google_cloud_scheduler_job" "daily_summary" {
+  name        = "daily-summary-scheduler"
+  description = "Trigger daily summary batch job"
+  schedule    = "0 6,12,18 * * *"
+  time_zone   = "Asia/Tokyo"
+  region      = var.region
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.daily_summary.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.cloud_scheduler.email
+    }
+  }
+
+  depends_on = [
+    google_project_service.required_apis,
+    google_cloud_run_v2_job.daily_summary,
+    google_project_iam_member.cloud_scheduler_run_invoker
+  ]
+}

--- a/terraform/cloud_sql.tf
+++ b/terraform/cloud_sql.tf
@@ -1,5 +1,5 @@
 # Cloud SQL
-# Summeryme AI Backend
+# Summaryme AI Backend
 
 # Cloud SQL インスタンス
 resource "google_sql_database_instance" "main" {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,5 +1,5 @@
 # IAM (Identity and Access Management)
-# Summeryme AI Backend
+# Summaryme AI Backend
 
 # Cloud Run サービス用のサービスアカウント
 resource "google_service_account" "cloud_run" {

--- a/terraform/infrastructure-diagram.md
+++ b/terraform/infrastructure-diagram.md
@@ -1,8 +1,8 @@
-# Summeryme AI Backend - インフラ構成図
+# Summaryme AI Backend - インフラ構成図
 
 ## アーキテクチャ概要
 
-このドキュメントは、Terraformで管理されているSummeryme AI Backendのインフラ構成を視覚化したものです。
+このドキュメントは、Terraformで管理されているSummaryme AI Backendのインフラ構成を視覚化したものです。
 
 ## インフラ構成図
 
@@ -56,7 +56,7 @@ flowchart TB
     User -->|HTTPS Requests| CloudRun
     GitHub -->|Deploy| CloudRun
     GitHub -->|Migrate| MigrationJob
-    
+
     %% Scheduler Flow
     ArticleScheduler -->|Trigger| ArticleSummaryJob
     DailyScheduler -->|Trigger| DailySummaryJob
@@ -94,7 +94,7 @@ flowchart TB
     SA_GitHub -.->|Assumes| GitHub
     SA_GitHub -.->|Deploy| CloudRun
     SA_GitHub -.->|Execute| MigrationJob
-    
+
     SA_Scheduler -.->|Assumes| ArticleScheduler
     SA_Scheduler -.->|Assumes| DailyScheduler
     SA_Scheduler -.->|Execute| ArticleSummaryJob
@@ -120,7 +120,7 @@ flowchart TB
 
 ```mermaid
 C4Context
-    title Summeryme AI Backend - System Context
+    title Summaryme AI Backend - System Context
 
     Person(user, "Users", "エンドユーザー")
     System_Ext(github, "GitHub Actions", "CI/CDパイプライン")
@@ -284,4 +284,4 @@ Cloud Run → Secret Manager (Google APIs経由)
 **生成日**: 2025/05/31
 **更新日**: 2025/06/22
 **Terraformバージョン**: 1.5+
-**プロジェクト**: Summeryme AI Backend
+**プロジェクト**: Summaryme AI Backend

--- a/terraform/infrastructure-diagram.md
+++ b/terraform/infrastructure-diagram.md
@@ -21,6 +21,14 @@ flowchart TB
         subgraph Compute["💻 Compute Services"]
             CloudRun[📦 Cloud Run Service<br/>Hono + TypeScript<br/>Port: 8080]
             MigrationJob[⚙️ Migration Job<br/>Prisma Migrate]
+            ArticleSummaryJob[📄 Article Summary Job<br/>記事要約バッチ]
+            DailySummaryJob[📋 Daily Summary Job<br/>日次要約バッチ]
+        end
+
+        %% Scheduler
+        subgraph Scheduler["⏰ Cloud Scheduler"]
+            ArticleScheduler["🕐 Article Scheduler<br/>5,11,17 JST"]
+            DailyScheduler["🕐 Daily Scheduler<br/>6,12,18 JST"]
         end
 
         %% VPC Network
@@ -32,13 +40,15 @@ flowchart TB
         %% Storage & Secrets
         subgraph Storage["💾 Storage & Secrets"]
             CloudSQL[🗄️ Cloud SQL MySQL 8.0<br/>db-f1-micro<br/>Private IP Only]
-            SecretManager[🔐 Secret Manager<br/>DB Password]
+            SecretManager[🔐 Secret Manager<br/>DB Password<br/>Gemini API Key]
+            GCS[📁 Cloud Storage<br/>Audio Files Bucket]
         end
 
         %% Security & IAM
         subgraph Security["🛡️ Security & IAM"]
             SA_CloudRun[👤 Cloud Run SA<br/>SQL Client<br/>Secret Accessor]
             SA_GitHub[👤 GitHub Actions SA<br/>Run Admin<br/>SQL Admin]
+            SA_Scheduler[👤 Scheduler SA<br/>Run Invoker]
         end
     end
 
@@ -46,23 +56,35 @@ flowchart TB
     User -->|HTTPS Requests| CloudRun
     GitHub -->|Deploy| CloudRun
     GitHub -->|Migrate| MigrationJob
+    
+    %% Scheduler Flow
+    ArticleScheduler -->|Trigger| ArticleSummaryJob
+    DailyScheduler -->|Trigger| DailySummaryJob
 
     %% Network Flow (Private Resources Only)
     CloudRun -->|Private Access| VPCConnector
     MigrationJob -->|Private Access| VPCConnector
+    ArticleSummaryJob -->|Private Access| VPCConnector
+    DailySummaryJob -->|Private Access| VPCConnector
     VPCConnector --> Subnet
 
     %% Direct Internet Access (No NAT needed)
     CloudRun -.->|Direct Internet<br/>Google APIs| Internet
     MigrationJob -.->|Direct Internet<br/>Google APIs| Internet
+    ArticleSummaryJob -.->|Direct Internet<br/>Google APIs| Internet
+    DailySummaryJob -.->|Direct Internet<br/>Google APIs| Internet
 
     %% Database Connections
     CloudRun -.->|Private Connection| CloudSQL
     MigrationJob -.->|Private Connection| CloudSQL
+    ArticleSummaryJob -.->|Private Connection| CloudSQL
+    DailySummaryJob -.->|Private Connection| CloudSQL
 
     %% Secret Access
     CloudRun -.->|Read Secrets| SecretManager
     MigrationJob -.->|Read Secrets| SecretManager
+    ArticleSummaryJob -.->|Read Secrets| SecretManager
+    DailySummaryJob -.->|Read Secrets| SecretManager
 
     %% IAM Relationships
     SA_CloudRun -.->|Assumes| CloudRun
@@ -72,6 +94,11 @@ flowchart TB
     SA_GitHub -.->|Assumes| GitHub
     SA_GitHub -.->|Deploy| CloudRun
     SA_GitHub -.->|Execute| MigrationJob
+    
+    SA_Scheduler -.->|Assumes| ArticleScheduler
+    SA_Scheduler -.->|Assumes| DailyScheduler
+    SA_Scheduler -.->|Execute| ArticleSummaryJob
+    SA_Scheduler -.->|Execute| DailySummaryJob
 
     %% Styling
     classDef internetClass fill:#e1f5fe,stroke:#01579b,stroke-width:2px
@@ -79,12 +106,14 @@ flowchart TB
     classDef networkClass fill:#e8f5e8,stroke:#1b5e20,stroke-width:2px
     classDef storageClass fill:#fff3e0,stroke:#e65100,stroke-width:2px
     classDef securityClass fill:#ffebee,stroke:#b71c1c,stroke-width:2px
+    classDef schedulerClass fill:#e8eaf6,stroke:#283593,stroke-width:2px
 
     class User,GitHub internetClass
-    class CloudRun,MigrationJob computeClass
+    class CloudRun,MigrationJob,ArticleSummaryJob,DailySummaryJob computeClass
     class VPCConnector,Subnet networkClass
-    class CloudSQL,SecretManager storageClass
-    class SA_CloudRun,SA_GitHub securityClass
+    class CloudSQL,SecretManager,GCS storageClass
+    class SA_CloudRun,SA_GitHub,SA_Scheduler securityClass
+    class ArticleScheduler,DailyScheduler schedulerClass
 ```
 
 ## 簡略版構成図（C4 Context Level）
@@ -166,6 +195,8 @@ flowchart LR
   - 自動スケーリング: 0-10インスタンス
   - ヘルスチェック: `/health`エンドポイント
 - **Migration Job**: Prismaマイグレーション実行用ジョブ
+- **Article Summary Job**: 記事要約バッチ処理
+- **Daily Summary Job**: 日次要約バッチ処理
 
 #### VPC Network
 - **VPC Connector**: Cloud RunとVPC間の接続
@@ -175,21 +206,33 @@ flowchart LR
 - **Cloud Router**: VPCルーティング管理
 - **Cloud NAT**: アウトバウンドインターネットアクセス
 
+#### Cloud Scheduler
+- **Article Summary Scheduler**: 記事要約ジョブのスケジュール実行
+  - 実行時刻: 5時、11時、17時 (JST)
+- **Daily Summary Scheduler**: 日次要約ジョブのスケジュール実行
+  - 実行時刻: 6時、12時、18時 (JST)
+
 #### Storage & Secrets
 - **Cloud SQL MySQL**: メインデータベース
   - バージョン: MySQL 8.0
   - ティア: db-f1-micro
   - プライベート接続のみ
-- **Secret Manager**: データベースパスワード管理
+- **Secret Manager**: シークレット管理
+  - データベースパスワード
+  - Gemini APIキー
+- **Cloud Storage**: 音声ファイル保存用バケット
 
 #### Security & IAM
 - **Cloud Run Service Account**: Cloud Run用の最小権限
   - Cloud SQL Client
   - Secret Manager Accessor
+  - Storage Object Admin
 - **GitHub Actions Service Account**: CI/CD用権限
   - Cloud Run Admin
   - Cloud SQL Admin
   - Secret Manager Admin
+- **Cloud Scheduler Service Account**: スケジューラー用権限
+  - Cloud Run Invoker
 
 ## ネットワークフロー
 
@@ -204,13 +247,19 @@ GitHub Actions → Cloud Run Service (新バージョンデプロイ)
 GitHub Actions → Migration Job (データベースマイグレーション)
 ```
 
-### 3. アウトバウンド通信
+### 3. スケジュール実行
+```
+Cloud Scheduler → Article Summary Job (定期実行)
+Cloud Scheduler → Daily Summary Job (定期実行)
+```
+
+### 4. アウトバウンド通信
 ```
 Cloud Run → Direct Internet Access (Google Frontend経由)
 ※ Cloud NATは不要 - Cloud Runは直接インターネットアクセス可能
 ```
 
-### 4. プライベートリソースアクセス
+### 5. プライベートリソースアクセス
 ```
 Cloud Run → VPC Connector → Private Subnet → Cloud SQL (Private IP)
 Cloud Run → Secret Manager (Google APIs経由)
@@ -233,5 +282,6 @@ Cloud Run → Secret Manager (Google APIs経由)
 ---
 
 **生成日**: 2025/05/31
+**更新日**: 2025/06/22
 **Terraformバージョン**: 1.5+
 **プロジェクト**: Summeryme AI Backend

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -32,7 +32,8 @@ locals {
     "compute.googleapis.com",
     "servicenetworking.googleapis.com",
     "vpcaccess.googleapis.com",
-    "storage.googleapis.com"
+    "storage.googleapis.com",
+    "cloudscheduler.googleapis.com"
   ]
 
   # 環境別設定

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,5 +1,5 @@
 # ローカル変数定義
-# Summeryme AI Backend
+# Summaryme AI Backend
 
 locals {
   # サービス名

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,4 @@
-# Summeryme AI Backend - Main Configuration
+# Summaryme AI Backend - Main Configuration
 #
 # このファイルは、Terraformの設定ファイルの中心となるファイルです。
 # 各リソースは機能別に分離されたファイルで管理されています。

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -192,6 +192,35 @@ output "daily_summary_job_location" {
 }
 
 # =============================================================================
+# Cloud Scheduler Jobs
+# =============================================================================
+
+output "cloud_scheduler_service_account_email" {
+  description = "Email address of the Cloud Scheduler service account"
+  value       = google_service_account.cloud_scheduler.email
+}
+
+output "article_summary_scheduler_name" {
+  description = "Name of the article summary scheduler job"
+  value       = google_cloud_scheduler_job.article_summary.name
+}
+
+output "article_summary_scheduler_schedule" {
+  description = "Schedule for the article summary job"
+  value       = google_cloud_scheduler_job.article_summary.schedule
+}
+
+output "daily_summary_scheduler_name" {
+  description = "Name of the daily summary scheduler job"
+  value       = google_cloud_scheduler_job.daily_summary.name
+}
+
+output "daily_summary_scheduler_schedule" {
+  description = "Schedule for the daily summary job"
+  value       = google_cloud_scheduler_job.daily_summary.schedule
+}
+
+# =============================================================================
 # Project Information
 # =============================================================================
 
@@ -240,6 +269,15 @@ output "useful_commands" {
     # GCS commands
     list_audio_files_command  = "gsutil ls gs://${google_storage_bucket.audio_files.name}/"
     audio_bucket_info_command = "gsutil du -s gs://${google_storage_bucket.audio_files.name}/"
+
+    # Cloud Scheduler commands
+    list_schedulers_command                  = "gcloud scheduler jobs list --location=${var.region}"
+    run_article_summary_scheduler_command    = "gcloud scheduler jobs run ${google_cloud_scheduler_job.article_summary.name} --location=${var.region}"
+    run_daily_summary_scheduler_command      = "gcloud scheduler jobs run ${google_cloud_scheduler_job.daily_summary.name} --location=${var.region}"
+    pause_article_summary_scheduler_command  = "gcloud scheduler jobs pause ${google_cloud_scheduler_job.article_summary.name} --location=${var.region}"
+    pause_daily_summary_scheduler_command    = "gcloud scheduler jobs pause ${google_cloud_scheduler_job.daily_summary.name} --location=${var.region}"
+    resume_article_summary_scheduler_command = "gcloud scheduler jobs resume ${google_cloud_scheduler_job.article_summary.name} --location=${var.region}"
+    resume_daily_summary_scheduler_command   = "gcloud scheduler jobs resume ${google_cloud_scheduler_job.daily_summary.name} --location=${var.region}"
   }
 }
 
@@ -271,6 +309,17 @@ output "resource_summary" {
       }
     }
 
+    cloud_scheduler_jobs = {
+      article_summary = {
+        name     = google_cloud_scheduler_job.article_summary.name
+        schedule = google_cloud_scheduler_job.article_summary.schedule
+      }
+      daily_summary = {
+        name     = google_cloud_scheduler_job.daily_summary.name
+        schedule = google_cloud_scheduler_job.daily_summary.schedule
+      }
+    }
+
     vpc_network = {
       name      = google_compute_network.main.name
       subnet    = google_compute_subnetwork.main.name
@@ -289,8 +338,9 @@ output "resource_summary" {
     }
 
     service_accounts = {
-      cloud_run      = google_service_account.cloud_run.email
-      github_actions = google_service_account.github_actions.email
+      cloud_run       = google_service_account.cloud_run.email
+      github_actions  = google_service_account.github_actions.email
+      cloud_scheduler = google_service_account.cloud_scheduler.email
     }
 
     secrets = {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,4 +1,4 @@
-# Outputs for Summeryme AI Backend
+# Outputs for Summaryme AI Backend
 # Terraform Configuration
 
 # =============================================================================

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,5 +1,5 @@
 # プロバイダー設定
-# Summeryme AI Backend
+# Summaryme AI Backend
 
 terraform {
   required_version = ">= 1.0"

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,5 +1,5 @@
 # Secret Manager
-# Summeryme AI Backend
+# Summaryme AI Backend
 
 # データベースパスワード生成
 resource "random_password" "db_password" {

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,5 +1,5 @@
 # Google Cloud Storage
-# Summeryme AI Backend
+# Summaryme AI Backend
 
 # 音声ファイル保存用のGCSバケット
 resource "google_storage_bucket" "audio_files" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,4 +1,4 @@
-# Terraform Variables for Summeryme AI Backend
+# Terraform Variables for Summaryme AI Backend
 # このファイルをコピーして terraform.tfvars を作成し、実際の値を設定してください
 
 # 必須項目

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Variables for Summeryme AI Backend
+# Variables for Summaryme AI Backend
 # Terraform Configuration
 
 # =============================================================================

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,5 +1,5 @@
 # VPC Network
-# Summeryme AI Backend
+# Summaryme AI Backend
 
 # VPCネットワーク
 resource "google_compute_network" "main" {


### PR DESCRIPTION
## 概要
バッチジョブをCloud Schedulerでスケジュール実行できるようにしました。

## 変更内容

### Cloud Scheduler の実装
- 記事要約ジョブ (`article-summary-scheduler`)
  - スケジュール: 毎日5時、11時、17時（JST）
  - 対象: `article-summary-job`
- 日次要約ジョブ (`daily-summary-scheduler`)  
  - スケジュール: 毎日6時、12時、18時（JST）
  - 対象: `daily-summary-job`

### セキュリティ設定
- 専用サービスアカウント `${service_name}-scheduler-sa` を作成
- Cloud Run Jobs を実行するための `roles/run.invoker` 権限を付与

### インフラ構成の追加
- `cloud_scheduler.tf`: Cloud Scheduler リソース定義
- `SCHEDULER_SETUP.md`: セットアップガイド
- Makefile に Cloud Scheduler 操作コマンドを追加
  - `make scheduler-list`: ジョブ一覧表示
  - `make scheduler-run-article`: 記事要約の手動実行
  - `make scheduler-run-daily`: 日次要約の手動実行
  - `make scheduler-pause-all`: 全ジョブ一時停止
  - `make scheduler-resume-all`: 全ジョブ再開

### API 有効化
- `cloudscheduler.googleapis.com` を必要APIリストに追加

## テスト方法
```bash
# デプロイ
cd terraform
make apply

# スケジューラー確認
make scheduler-list

# 手動実行テスト
make scheduler-run-article
make scheduler-run-daily
```

## 関連資料
- [SCHEDULER_SETUP.md](terraform/SCHEDULER_SETUP.md) - 詳細なセットアップガイド

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>